### PR TITLE
chore!: gatekeeper service fqcn

### DIFF
--- a/DependencyInjection/Compiler/GateKeeperCompilerPass.php
+++ b/DependencyInjection/Compiler/GateKeeperCompilerPass.php
@@ -6,7 +6,7 @@
 
 namespace GateKeeperBundle\DependencyInjection\Compiler;
 
-
+use GateKeeper\GateKeeper;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -22,7 +22,7 @@ class GateKeeperCompilerPass implements CompilerPassInterface
 	 */
 	public function process(ContainerBuilder $container)
 	{
-		if (!$container->hasDefinition('gatekeeper'))
+		if (!$container->hasDefinition(GateKeeper::class))
 		{
 			return;
 		}
@@ -30,7 +30,7 @@ class GateKeeperCompilerPass implements CompilerPassInterface
 		$definition = $container->getDefinition('gatekeeper.voter');
 		$definition->addArgument(new Reference($container->getParameter('gatekeeper.provider.service')));
 
-		$definition = $container->getDefinition('gatekeeper');
+		$definition = $container->getDefinition(GateKeeper::class);
 		$definition->addArgument(new Reference($container->getParameter('gatekeeper.repository.service')));
 
 		$taggedServices = $container->findTaggedServiceIds('gatekeeper.access');

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,6 +5,7 @@ services:
 
     gatekeeper:
         alias: GateKeeper\GateKeeper
+        deprecated: true
         public: true
 
     gatekeeper.repository.dummy:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,14 +1,10 @@
-parameters:
-    gatekeeper.class: GateKeeper\GateKeeper
-    gatekeeper.access.allow.class: GateKeeperBundle\Access\Allow
-    gatekeeper.access.deny.class: GateKeeperBundle\Access\Deny
-
 services:
     GateKeeper\GateKeeper:
-        alias: 'gatekeeper'
+        class: GateKeeper\GateKeeper
+        public: true
 
     gatekeeper:
-        class: '%gatekeeper.class%'
+        alias: GateKeeper\GateKeeper
         public: true
 
     gatekeeper.repository.dummy:
@@ -25,12 +21,12 @@ services:
 
     gatekeeper.access.allow:
         public: false
-        class: '%gatekeeper.access.allow.class%'
+        class: GateKeeperBundle\Access\Allow
         tags:
           - { name: gatekeeper.access }
 
     gatekeeper.access.deny:
         public: false
-        class: '%gatekeeper.access.deny.class%'
+        class: GateKeeperBundle\Access\Deny
         tags:
           - { name: gatekeeper.access }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,7 +15,7 @@ services:
 
     gatekeeper.voter:
         class: GateKeeperBundle\Voter\GateKeeper
-        arguments: ["@gatekeeper"]
+        arguments: ['@GateKeeper\GateKeeper']
         tags:
           - { name: security.voter }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,10 @@ services:
         class: GateKeeper\GateKeeper
         public: true
 
+    gatekeeper:
+        alias: GateKeeper\GateKeeper
+        public: true
+
     gatekeeper.repository.dummy:
         class: GateKeeper\Repository\DummyRepository
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,10 +3,6 @@ services:
         class: GateKeeper\GateKeeper
         public: true
 
-    gatekeeper:
-        alias: GateKeeper\GateKeeper
-        public: true
-
     gatekeeper.repository.dummy:
         class: GateKeeper\Repository\DummyRepository
 


### PR DESCRIPTION
* ability to use the FQCN service directly in the monolith-app (50 deprecation logs each time)
* removed class params as these weren't used at all

---

![image](https://github.com/user-attachments/assets/b019d5d2-c1b9-4b10-8d98-3db01486a6ea)
